### PR TITLE
refactor: change pvc type to netapp

### DIFF
--- a/visr/templates/visr-template.yaml
+++ b/visr/templates/visr-template.yaml
@@ -30,7 +30,7 @@ spec:
         resources:
           requests:
             storage: 1Gi
-        storageClassName: local-path
+        storageClassName: netapp
     - metadata:
         name: tmpdir
       spec:
@@ -38,7 +38,7 @@ spec:
         resources:
           requests:
             storage: 1Gi
-        storageClassName: local-path
+        storageClassName: netapp
 
   templates:
     - name: mount-files


### PR DESCRIPTION
Cloud has deprecated local-path PVC's so we're in the process of migrating all the existing templates to netapp. I've updated all the test-rig PVC in this PR. Let anyone in the workflows team know if there's any issues with this update. 